### PR TITLE
bump rustls-webpki from 0.102.8 to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,44 +357,39 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.0"
+version = "0.13.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59057b878509d88952425fe694a2806e468612bde2d71943f3cd8034935b5032"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
- "paste",
  "regex",
 ]
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.24.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "paste",
 ]
 
 [[package]]
@@ -438,16 +433,14 @@ checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -456,7 +449,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.95",
- "which",
 ]
 
 [[package]]
@@ -544,10 +536,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -683,9 +676,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1062,6 +1055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,15 +1364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1704,12 +1694,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -2393,9 +2377,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2438,7 +2422,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -2503,7 +2487,7 @@ name = "rustls-fuzzing-provider"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "watfaq-rustls",
 ]
 
@@ -2521,9 +2505,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-post-quantum"
@@ -2553,7 +2540,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "sha2",
  "signature",
  "watfaq-rustls",
@@ -2577,6 +2564,17 @@ name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3166,7 +3164,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "rustversion",
  "serde",
  "serde_json",
@@ -3196,18 +3194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ subtle = { version = "2.5.0", default-features = false }
 time = { version = "0.3.6", default-features = false }
 tikv-jemallocator = "0.6"
 tokio = { version = "1.34", features = ["io-util", "macros", "net", "rt"]}
-webpki = { package = "rustls-webpki", version = "0.102.8", features = ["alloc"], default-features = false }
+webpki = { package = "rustls-webpki", version = "0.103.13", features = ["alloc"], default-features = false }
 webpki-roots = "0.26"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 x509-parser = "0.16"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -37,7 +37,7 @@ zlib-rs = { workspace = true, optional = true }
 default = ["aws_lc_rs", "logging", "std", "tls12"]
 std = ["webpki/std", "pki-types/std", "once_cell/std"]
 logging = ["log"]
-aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
+aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws-lc-rs"]
 aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
 ring = ["dep:ring", "webpki/ring", "dep:x25519-dalek"]

--- a/rustls/src/crypto/aws_lc_rs/sign.rs
+++ b/rustls/src/crypto/aws_lc_rs/sign.rs
@@ -7,8 +7,7 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::fmt::{self, Debug, Formatter};
 
-use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer};
-use webpki::alg_id;
+use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer, alg_id};
 
 use super::ring_like::rand::SystemRandom;
 use super::ring_like::signature::{self, EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaKeyPair};

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -7,8 +7,7 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::fmt::{self, Debug, Formatter};
 
-use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer};
-use webpki::alg_id;
+use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer, alg_id};
 
 use super::ring_like::rand::{SecureRandom, SystemRandom};
 use super::ring_like::signature::{self, EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaKeyPair};

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -58,10 +58,10 @@ fn pki_error(error: webpki::Error) -> Error {
     use webpki::Error::*;
     match error {
         BadDer | BadDerTime | TrailingData(_) => CertificateError::BadEncoding.into(),
-        CertNotValidYet => CertificateError::NotValidYet.into(),
-        CertExpired | InvalidCertValidity => CertificateError::Expired.into(),
+        CertNotValidYet { .. } => CertificateError::NotValidYet.into(),
+        CertExpired { .. } | InvalidCertValidity => CertificateError::Expired.into(),
         UnknownIssuer => CertificateError::UnknownIssuer.into(),
-        CertNotValidForName => CertificateError::NotValidForName.into(),
+        CertNotValidForName(_) => CertificateError::NotValidForName.into(),
         CertRevoked => CertificateError::Revoked.into(),
         UnknownRevocationStatus => CertificateError::UnknownRevocationStatus.into(),
         CrlExpired => CertificateError::ExpiredRevocationList.into(),

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -64,16 +64,20 @@ fn pki_error(error: webpki::Error) -> Error {
         CertNotValidForName(_) => CertificateError::NotValidForName.into(),
         CertRevoked => CertificateError::Revoked.into(),
         UnknownRevocationStatus => CertificateError::UnknownRevocationStatus.into(),
-        CrlExpired => CertificateError::ExpiredRevocationList.into(),
+        CrlExpired { .. } => CertificateError::ExpiredRevocationList.into(),
         IssuerNotCrlSigner => CertRevocationListError::IssuerInvalidForCrl.into(),
 
         InvalidSignatureForPublicKey
         | UnsupportedSignatureAlgorithm
-        | UnsupportedSignatureAlgorithmForPublicKey => CertificateError::BadSignature.into(),
+        | UnsupportedSignatureAlgorithmForPublicKey
+        | UnsupportedSignatureAlgorithmForPublicKeyContext(_)
+        | UnsupportedSignatureAlgorithmContext(_) => CertificateError::BadSignature.into(),
 
         InvalidCrlSignatureForPublicKey
         | UnsupportedCrlSignatureAlgorithm
-        | UnsupportedCrlSignatureAlgorithmForPublicKey => {
+        | UnsupportedCrlSignatureAlgorithmForPublicKey
+        | UnsupportedCrlSignatureAlgorithmForPublicKeyContext(_)
+        | UnsupportedCrlSignatureAlgorithmContext(_) => {
             CertRevocationListError::BadSignature.into()
         }
 
@@ -90,7 +94,9 @@ fn crl_error(e: webpki::Error) -> CertRevocationListError {
     match e {
         InvalidCrlSignatureForPublicKey
         | UnsupportedCrlSignatureAlgorithm
-        | UnsupportedCrlSignatureAlgorithmForPublicKey => CertRevocationListError::BadSignature,
+        | UnsupportedCrlSignatureAlgorithmForPublicKey
+        | UnsupportedCrlSignatureAlgorithmForPublicKeyContext(_)
+        | UnsupportedCrlSignatureAlgorithmContext(_) => CertRevocationListError::BadSignature,
         InvalidCrlNumber => CertRevocationListError::InvalidCrlNumber,
         InvalidSerialNumber => CertRevocationListError::InvalidRevokedCertSerialNumber,
         IssuerNotCrlSigner => CertRevocationListError::IssuerInvalidForCrl,
@@ -118,6 +124,7 @@ fn parse_crls(
 }
 
 mod tests {
+    use alloc::vec;
     #[test]
     fn pki_crl_errors() {
         use super::{pki_error, CertRevocationListError, CertificateError, Error};
@@ -132,7 +139,12 @@ mod tests {
             Error::InvalidCertRevocationList(CertRevocationListError::BadSignature),
         );
         assert_eq!(
-            pki_error(webpki::Error::UnsupportedCrlSignatureAlgorithmForPublicKey),
+            pki_error(webpki::Error::UnsupportedCrlSignatureAlgorithmForPublicKeyContext(
+                webpki::UnsupportedSignatureAlgorithmForPublicKeyContext {
+                    signature_algorithm_id: vec![],
+                    public_key_algorithm_id: vec![],
+                }
+            )),
             Error::InvalidCertRevocationList(CertRevocationListError::BadSignature),
         );
 
@@ -161,7 +173,12 @@ mod tests {
                 BadSignature,
             ),
             (
-                webpki::Error::UnsupportedCrlSignatureAlgorithmForPublicKey,
+                webpki::Error::UnsupportedCrlSignatureAlgorithmForPublicKeyContext(
+                    webpki::UnsupportedSignatureAlgorithmForPublicKeyContext {
+                        signature_algorithm_id: vec![],
+                        public_key_algorithm_id: vec![],
+                    },
+                ),
                 BadSignature,
             ),
             (webpki::Error::InvalidCrlNumber, InvalidCrlNumber),
@@ -189,7 +206,7 @@ mod tests {
             ),
         ];
         for t in testcases {
-            assert_eq!(crl_error(t.0), t.1);
+            assert_eq!(crl_error(t.0.clone()), t.1);
         }
 
         assert!(matches!(


### PR DESCRIPTION
## Summary

Bumps `rustls-webpki` from `0.102.8` to `0.103.13` to resolve a Dependabot security advisory in the `clash-rs` repo.

## Changes

- **`Cargo.toml`**: Update `webpki` workspace dep to `0.103.13`
- **`rustls/Cargo.toml`**: Fix feature flag: `webpki/aws_lc_rs` → `webpki/aws-lc-rs` (renamed in 0.103)
- **`rustls/src/crypto/{ring,aws_lc_rs}/sign.rs`**: `alg_id` moved from `webpki::alg_id` → `pki_types::alg_id`
- **`rustls/src/webpki/mod.rs`**: Fix error variant patterns — `CertExpired`/`CertNotValidYet` are now struct variants (`{ .. }`), `CertNotValidForName` is now a tuple variant (`(_)`)