### PR TITLE
client: let the ClientHello be shaped like someone else

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "subtle",
  "time",
  "webpki-roots 1.0.7",
+ "x25519-dalek",
  "x509-parser 0.17.0",
  "zeroize",
  "zlib-rs",

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -17,8 +17,13 @@ use crate::{WantsVersions, compress, verify, versions};
 impl ConfigBuilder<ClientConfig, WantsVersions> {
     /// Enable Encrypted Client Hello (ECH) in the given mode.
     ///
-    /// This implicitly selects TLS 1.3 as the only supported protocol version to meet the
-    /// requirement to support ECH.
+    /// [`EchMode::Enable`] implicitly selects TLS 1.3 as the only supported protocol version,
+    /// to meet the requirement to support ECH.
+    ///
+    /// [`EchMode::Grease`] does not: it sends a placeholder extension and negotiates nothing,
+    /// so there is no version requirement to meet. Pinning TLS 1.3 on its account would drop
+    /// TLS 1.2 from the hello - narrowing what the connection can do, and changing the hello
+    /// itself, which is the opposite of what a client GREASEing to blend in wants.
     ///
     /// The `ClientConfig` that will be produced by this builder will be specific to the provided
     /// [`crate::client::EchConfig`] and may not be appropriate for all connections made by the program.
@@ -28,7 +33,10 @@ impl ConfigBuilder<ClientConfig, WantsVersions> {
         self,
         mode: EchMode,
     ) -> Result<ConfigBuilder<ClientConfig, WantsVerifier>, Error> {
-        let mut res = self.with_protocol_versions(&[&TLS13][..])?;
+        let mut res = match mode {
+            EchMode::Enable(_) => self.with_protocol_versions(&[&TLS13][..])?,
+            EchMode::Grease(_) => self.with_safe_default_protocol_versions()?,
+        };
         res.state.client_ech_mode = Some(mode);
         Ok(res)
     }

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -5,7 +5,7 @@ use pki_types::{CertificateDer, PrivateKeyDer};
 
 use super::client_conn::Resumption;
 use crate::builder::{ConfigBuilder, WantsVerifier};
-use crate::client::{ClientConfig, EchMode, ResolvesClientCert, handy};
+use crate::client::{ClientConfig, ClientHelloProfile, EchMode, ResolvesClientCert, handy};
 use crate::error::Error;
 use crate::key_log::NoKeyLog;
 use crate::sign::{CertifiedKey, SingleCertAndKey};
@@ -222,6 +222,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             cert_decompressors: compress::default_cert_decompressors().to_vec(),
             ech_mode: self.state.client_ech_mode,
             reality_config: self.state.reality_config,
+            client_hello_profile: Arc::new(ClientHelloProfile::default()),
         }
     }
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -10,7 +10,7 @@ use super::hs;
 #[cfg(feature = "std")]
 use crate::WantsVerifier;
 use crate::builder::ConfigBuilder;
-use crate::client::{EchMode, EchStatus};
+use crate::client::{ClientHelloProfile, EchMode, EchStatus};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
@@ -290,6 +290,12 @@ pub struct ClientConfig {
 
     /// VLESS Reality protocol configuration. The default is None (disabled).
     pub(super) reality_config: Option<Arc<crate::client::reality::RealityConfig>>,
+
+    /// How the `ClientHello` should look on the wire.
+    ///
+    /// The default sends what rustls has always sent. See
+    /// [`ClientHelloProfile`] for why anyone would want something else.
+    pub client_hello_profile: Arc<ClientHelloProfile>,
 }
 
 impl ClientConfig {

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -894,7 +894,6 @@ impl ConnectionCore<ClientConnectionData> {
             sendable_plaintext: None,
         };
 
-
         let state =
             hs::start_handshake::<fn(&[u8]) -> [u8; 32]>(name, extra_exts, config, &mut cx, None)?;
         Ok(Self::new(state, data, common_state))

--- a/rustls/src/client/client_hello_profile.rs
+++ b/rustls/src/client/client_hello_profile.rs
@@ -1,0 +1,236 @@
+//! Shaping the `ClientHello` to resemble another TLS implementation.
+//!
+//! rustls sends the `ClientHello` rustls needs, and that hello is recognisably
+//! rustls: a censor or a CDN can tell it apart from a browser by the set of
+//! extensions alone, before a single byte of application data is exchanged.
+//! For a plain HTTPS client that is nobody's problem. For a client whose whole
+//! job is to be indistinguishable from a browser - anything built on Reality,
+//! ShadowTLS or similar - it is the problem.
+//!
+//! This module carries the parts of that job which belong in the TLS stack,
+//! and only those: GREASE (RFC 8701), and room for extensions rustls has no
+//! reason to model. Which extensions a given browser sends, in what order,
+//! with what bodies, is not knowledge rustls should hold - that lives in the
+//! caller, expressed through [`RawExtension`].
+
+use alloc::vec::Vec;
+
+use crate::Error;
+use crate::crypto::SecureRandom;
+use crate::msgs::handshake::RawExtension;
+
+/// The sixteen values RFC 8701 reserves for GREASE.
+///
+/// They are spread across the codepoint space on purpose: a peer that special
+/// cases one of them, or that chokes on an unknown value, is caught early
+/// rather than years later when a real extension takes that number.
+pub(crate) const GREASE_VALUES: [u16; 16] = [
+    0x0a0a, 0x1a1a, 0x2a2a, 0x3a3a, 0x4a4a, 0x5a5a, 0x6a6a, 0x7a7a, 0x8a8a, 0x9a9a, 0xaaaa, 0xbaba,
+    0xcaca, 0xdada, 0xeaea, 0xfafa,
+];
+
+/// How the `ClientHello` should look on the wire.
+///
+/// The default sends what rustls has always sent. Every field below moves the
+/// hello towards resembling something else, and none of them change what is
+/// negotiated: GREASE values are ignored by any correct peer, and verbatim
+/// extensions are the caller's business.
+#[derive(Clone, Debug, Default)]
+pub struct ClientHelloProfile {
+    /// Advertise GREASE values (RFC 8701).
+    ///
+    /// When set, a reserved value is added to the cipher suite list, the
+    /// supported groups list, the key share list and the supported versions
+    /// list, and two more appear as extensions of their own - one first in the
+    /// extension list, one just before the trailing extensions. That is what
+    /// browsers built on BoringSSL do, down to the bodies of the two: the
+    /// first empty, the second a single zero byte.
+    pub grease: bool,
+
+    /// Extensions written before everything rustls generates.
+    pub prepend_extensions: Vec<RawExtension>,
+
+    /// Extensions written after everything rustls generates.
+    ///
+    /// They still precede the extensions the standard pins to the end of the
+    /// list - encrypted client hello and the pre-shared key offer.
+    pub append_extensions: Vec<RawExtension>,
+
+    /// Pad the hello out with a `padding` extension (RFC 7685).
+    pub padding: Option<Padding>,
+
+    /// The cipher suite list to put on the wire, in this order.
+    ///
+    /// By default rustls advertises the suites its provider holds, which is
+    /// also the set it can negotiate. Those two are the same thing right up
+    /// until the hello has to resemble an implementation that supports suites
+    /// rustls does not - and every browser does, static RSA key exchange being
+    /// the obvious case. The suite count and their order both feed the common
+    /// fingerprints, so leaving them at what rustls happens to support gives
+    /// the game away on its own.
+    ///
+    /// # This is a loaded gun
+    ///
+    /// Suites listed here are advertised and nothing more. If the peer selects
+    /// one that the provider cannot actually do, the handshake fails - late,
+    /// after the server has already committed to it. Two consequences:
+    ///
+    /// - keep every suite the provider supports in the list, or connections
+    ///   will fail against perfectly ordinary servers;
+    /// - only advertise suites rustls lacks where the peer cannot pick them,
+    ///   which in practice means a peer pinned to TLS 1.3.
+    ///
+    /// Nothing else in the hello is derived from this field: the versions and
+    /// key shares offered are still rustls own.
+    pub cipher_suites: Option<Vec<u16>>,
+}
+
+/// When and how far to pad the `ClientHello`.
+///
+/// Padding exists because some middleboxes mishandle a hello whose length
+/// lands in a particular range; browsers therefore pad out of that range
+/// unconditionally. Its side effect is that hello length stops being a
+/// distinguishing feature, which is why it belongs here.
+#[derive(Clone, Copy, Debug)]
+pub struct Padding {
+    /// Pad only if the hello has reached this length. Shorter helloes are left
+    /// alone: padding a small hello would itself stand out.
+    pub only_above: usize,
+
+    /// Length to pad up to.
+    pub up_to: usize,
+}
+
+impl Default for Padding {
+    /// The rule BoringSSL applies, and so every browser built on it.
+    fn default() -> Self {
+        Self {
+            only_above: 0x100,
+            up_to: 0x200,
+        }
+    }
+}
+
+impl Padding {
+    /// How many zero bytes the padding extension body needs, given the length
+    /// the hello has reached without it.
+    ///
+    /// `None` when no padding extension should be sent at all - which is not
+    /// the same as an empty one, that being a visible difference on the wire.
+    pub(crate) fn body_len(&self, hello_len: usize) -> Option<usize> {
+        if hello_len < self.only_above || hello_len >= self.up_to {
+            return None;
+        }
+
+        // The extension header is four bytes and is itself part of what we are
+        // padding. If those four alone overshoot the target there is nothing
+        // sensible left to add, so send an empty body rather than a negative
+        // one.
+        Some(
+            self.up_to
+                .saturating_sub(hello_len)
+                .saturating_sub(4),
+        )
+    }
+}
+
+/// GREASE values chosen for one connection.
+///
+/// Picked once and kept, because a `HelloRetryRequest` makes us send a second
+/// hello which has to agree with the first.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Grease {
+    pub(crate) cipher_suite: u16,
+    pub(crate) named_group: u16,
+    pub(crate) version: u16,
+    pub(crate) first_extension: u16,
+    pub(crate) last_extension: u16,
+}
+
+impl Grease {
+    /// The single byte browsers put in the GREASE key share.
+    ///
+    /// The content is meaningless by definition; the length is not, so it is
+    /// fixed here rather than left to chance.
+    pub(crate) const KEY_SHARE_PAYLOAD: [u8; 1] = [0x00];
+
+    /// The body of the trailing GREASE extension.
+    ///
+    /// The leading one is empty and this one is a single zero byte. There is
+    /// no reason for the asymmetry beyond BoringSSL doing it that way, and
+    /// that is reason enough: matching it is the entire point.
+    pub(crate) const LAST_EXTENSION_PAYLOAD: [u8; 1] = [0x00];
+
+    pub(crate) fn new(random: &'static dyn SecureRandom) -> Result<Self, Error> {
+        let mut seed = [0u8; 5];
+        random.fill(&mut seed)?;
+
+        let pick = |byte: u8| GREASE_VALUES[usize::from(byte & 0x0f)];
+
+        // The two extension placeholders must differ: two extensions of the
+        // same type in one hello is a protocol error, and a peer rejecting it
+        // would be right to.
+        let first_extension = pick(seed[3]);
+        let mut last_extension = pick(seed[4]);
+        if last_extension == first_extension {
+            last_extension = GREASE_VALUES[usize::from(seed[4].wrapping_add(1) & 0x0f)];
+        }
+
+        Ok(Self {
+            cipher_suite: pick(seed[0]),
+            named_group: pick(seed[1]),
+            version: pick(seed[2]),
+            first_extension,
+            last_extension,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn padding_follows_the_boringssl_rule() {
+        let padding = Padding::default();
+
+        // Below the window: left alone.
+        assert_eq!(padding.body_len(0xff), None);
+        // At the bottom edge: padded up to the target, header included.
+        assert_eq!(padding.body_len(0x100), Some(0x200 - 0x100 - 4));
+        // Room for a body.
+        assert_eq!(padding.body_len(0x1f0), Some(0x200 - 0x1f0 - 4));
+        // Too close to the target for the four byte header to fit: an empty
+        // extension goes out anyway, overshooting by those four bytes. That is
+        // what BoringSSL does, and matching it is the point.
+        assert_eq!(padding.body_len(0x1ff), Some(0));
+        // At and above the target: nothing to do.
+        assert_eq!(padding.body_len(0x200), None);
+        assert_eq!(padding.body_len(0x400), None);
+    }
+
+    #[test]
+    fn padding_never_asks_for_a_negative_body() {
+        // Four bytes short of the target there is no room for a body, but the
+        // extension is still sent - an absent extension and an empty one look
+        // different on the wire.
+        let padding = Padding {
+            only_above: 0,
+            up_to: 10,
+        };
+        assert_eq!(padding.body_len(8), Some(0));
+        assert_eq!(padding.body_len(7), Some(0));
+        assert_eq!(padding.body_len(6), Some(0));
+        assert_eq!(padding.body_len(5), Some(1));
+    }
+
+    #[test]
+    fn grease_values_are_the_reserved_ones() {
+        // Every value is 0xNaNa, which is what makes them recognisable.
+        for value in GREASE_VALUES {
+            let [high, low] = value.to_be_bytes();
+            assert_eq!(high, low);
+            assert_eq!(low & 0x0f, 0x0a);
+        }
+    }
+}

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use super::ResolvesClientCert;
+use super::client_hello_profile::Grease;
 use crate::log::{debug, trace};
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::handshake::{CertificateChain, DistinguishedName, ProtocolName, ServerExtensions};
@@ -39,15 +40,28 @@ pub(super) struct ClientHelloDetails {
     pub(super) sent_extensions: Vec<ExtensionType>,
     pub(super) extension_order_seed: u16,
     pub(super) offered_cert_compression: bool,
+
+    /// GREASE values for this connection, if the profile asked for any.
+    ///
+    /// Chosen once and kept: a `HelloRetryRequest` makes us send a second
+    /// hello, and a peer that saw one set of GREASE values in the first and
+    /// another in the second has been handed a distinguishing feature for
+    /// free.
+    pub(super) grease: Option<Grease>,
 }
 
 impl ClientHelloDetails {
-    pub(super) fn new(alpn_protocols: Vec<ProtocolName>, extension_order_seed: u16) -> Self {
+    pub(super) fn new(
+        alpn_protocols: Vec<ProtocolName>,
+        extension_order_seed: u16,
+        grease: Option<Grease>,
+    ) -> Self {
         Self {
             alpn_protocols,
             sent_extensions: Vec::new(),
             extension_order_seed,
             offered_cert_compression: false,
+            grease,
         }
     }
 

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -235,7 +235,12 @@ impl EchGreaseConfig {
                 config: EchConfigPayload::V18(EchConfigContents {
                     key_config: HpkeKeyConfig {
                         config_id: config_id[0],
-                        kem_id: HpkeKem::DHKEM_P256_HKDF_SHA256,
+                        // The KEM the configured suite actually uses, not a
+                        // fixed one: it decides the length of `enc` below, and
+                        // that length is visible on the wire. A client
+                        // GREASEing with X25519 while claiming P-256 is
+                        // distinguishable from one that means it.
+                        kem_id: suite.kem,
                         public_key: PayloadU16::new(self.placeholder_key.0.clone()),
                         symmetric_cipher_suites: vec![suite.sym],
                     },

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use alloc::format;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::iter;
@@ -52,7 +53,9 @@ impl EchMode {
     pub fn fips(&self) -> bool {
         match self {
             Self::Enable(ech_config) => ech_config.suite.fips(),
-            Self::Grease(grease_config) => grease_config.suite.fips(),
+            Self::Grease(grease_config) => grease_config
+                .hpke
+                .is_some_and(|hpke| hpke.fips()),
         }
     }
 }
@@ -189,8 +192,17 @@ impl EchConfig {
 /// Configuration for GREASE Encrypted Client Hello.
 #[derive(Clone, Debug)]
 pub struct EchGreaseConfig {
-    pub(crate) suite: &'static dyn Hpke,
-    pub(crate) placeholder_key: HpkePublicKey,
+    pub(crate) suite: HpkeSuite,
+
+    /// The provider to encapsulate with, when there is one.
+    ///
+    /// GREASE carries no information: the payload is random, and the
+    /// encapsulated key is addressed to a public key nobody holds. A working
+    /// KEM is therefore a convenience here, not a requirement - and demanding
+    /// one shuts out providers that ship no HPKE at all, which is the opposite
+    /// of what GREASE is for. See [`Self::without_provider`].
+    pub(crate) hpke: Option<&'static dyn Hpke>,
+    pub(crate) placeholder_key: Option<HpkePublicKey>,
 }
 
 impl EchGreaseConfig {
@@ -205,9 +217,52 @@ impl EchGreaseConfig {
     /// [^0]: <https://www.rfc-editor.org/rfc/rfc8701>
     pub fn new(suite: &'static dyn Hpke, placeholder_key: HpkePublicKey) -> Self {
         Self {
-            suite,
-            placeholder_key,
+            suite: suite.suite(),
+            hpke: Some(suite),
+            placeholder_key: Some(placeholder_key),
         }
+    }
+
+    /// Construct a GREASE ECH configuration without an HPKE provider.
+    ///
+    /// The extension this produces is the same shape as the one
+    /// [`Self::new`] produces, and carries the same amount of information -
+    /// none. The encapsulated key is random bytes of the length the named KEM
+    /// implies rather than the output of a real encapsulation, which for
+    /// X25519 is not a distinction anyone can observe, and for the NIST curves
+    /// means a value that is not a point on the curve.
+    ///
+    /// Use it where the crypto provider has no HPKE to offer - `ring` has
+    /// none, and it is what embedded and MIPS builds use, since `aws-lc-rs`
+    /// does not support those targets. The alternative there is not a better
+    /// GREASE but no GREASE at all, and a hello one extension short of the
+    /// clients it means to blend in with.
+    ///
+    /// Returns an error for a KEM whose encapsulated key length this crate
+    /// does not know, or an AEAD with no tag length.
+    pub fn without_provider(suite: HpkeSuite) -> Result<Self, Error> {
+        if suite
+            .kem
+            .encapsulated_key_len()
+            .is_none()
+        {
+            return Err(Error::General(format!(
+                "unknown encapsulated key length for {:?}",
+                suite.kem
+            )));
+        }
+        if suite.sym.aead_id.tag_len().is_none() {
+            return Err(Error::General(format!(
+                "unknown tag length for {:?}",
+                suite.sym.aead_id
+            )));
+        }
+
+        Ok(Self {
+            suite,
+            hpke: None,
+            placeholder_key: None,
+        })
     }
 
     /// Build a GREASE ECH extension based on the placeholder configuration.
@@ -226,35 +281,78 @@ impl EchGreaseConfig {
         let mut config_id: [u8; 1] = [0; 1];
         secure_random.fill(&mut config_id[..])?;
 
-        let suite = self.suite.suite();
+        let suite = self.suite;
+
+        // The KEM the configured suite actually uses, not a fixed one: it
+        // decides the length of `enc` below, and that length is visible on the
+        // wire. A client GREASEing with X25519 while sending a P-256 sized key
+        // is distinguishable from one that means it.
+        // Without a provider there is no key to encapsulate to, so a random
+        // value of the right length stands in for both the recipient key and
+        // the encapsulated one. Neither is read by anything: the first is only
+        // there because the config type will not hold an empty key, and the
+        // second goes on the wire where, for X25519, random and real are the
+        // same thing to anyone looking.
+        let mut filler = vec![
+            0;
+            suite
+                .kem
+                .encapsulated_key_len()
+                .ok_or_else(|| Error::General(format!(
+                    "unknown encapsulated key length for {:?}",
+                    suite.kem
+                )))?
+        ];
+        if self.placeholder_key.is_none() {
+            secure_random.fill(&mut filler)?;
+        }
+
+        let contents = EchConfigContents {
+            key_config: HpkeKeyConfig {
+                config_id: config_id[0],
+                kem_id: suite.kem,
+                public_key: PayloadU16::new(
+                    self.placeholder_key
+                        .as_ref()
+                        .map(|key| key.0.clone())
+                        .unwrap_or_else(|| filler.clone()),
+                ),
+                symmetric_cipher_suites: vec![suite.sym],
+            },
+            maximum_name_length: 0,
+            public_name: DnsName::try_from("filler").unwrap(),
+            extensions: Vec::default(),
+        };
 
         // Construct a dummy ECH state - we don't have a real ECH config from a server since
         // this is for GREASE.
-        let mut grease_state = EchState::new(
-            &EchConfig {
-                config: EchConfigPayload::V18(EchConfigContents {
-                    key_config: HpkeKeyConfig {
-                        config_id: config_id[0],
-                        // The KEM the configured suite actually uses, not a
-                        // fixed one: it decides the length of `enc` below, and
-                        // that length is visible on the wire. A client
-                        // GREASEing with X25519 while claiming P-256 is
-                        // distinguishable from one that means it.
-                        kem_id: suite.kem,
-                        public_key: PayloadU16::new(self.placeholder_key.0.clone()),
-                        symmetric_cipher_suites: vec![suite.sym],
-                    },
-                    maximum_name_length: 0,
-                    public_name: DnsName::try_from("filler").unwrap(),
-                    extensions: Vec::default(),
-                }),
-                suite: self.suite,
-            },
-            inner_name,
-            false,
-            secure_random,
-            false, // Does not matter if we enable/disable SNI here. Inner hello is not used.
-        )?;
+        //
+        // `enable_sni` is false either way: the inner hello is never sent, it
+        // exists only so the payload below is the length a real one would be.
+        let mut grease_state = match (self.hpke, &self.placeholder_key) {
+            (Some(hpke), Some(placeholder_key)) => EchState::new(
+                &EchConfig {
+                    config: EchConfigPayload::V18(contents),
+                    suite: hpke,
+                },
+                inner_name,
+                false,
+                secure_random,
+                false,
+            )?,
+            // No provider to encapsulate with, so the encapsulated key is
+            // random bytes of the length the KEM implies. Nothing downstream
+            // reads it, and nothing on the wire can tell the difference for
+            // X25519.
+            _ => EchState::grease(
+                &contents,
+                suite.sym,
+                EncapsulatedSecret(filler),
+                inner_name,
+                secure_random,
+                false,
+            )?,
+        };
 
         // Construct an inner hello using the outer hello - this allows us to know the size of
         // dummy payload we should use for the GREASE extension.
@@ -313,7 +411,12 @@ pub(crate) struct EchState {
     // A source of secure random data.
     secure_random: &'static dyn SecureRandom,
     // An HPKE sealer context that can be used for encrypting ECH data.
-    sender: Box<dyn HpkeSealer>,
+    /// `None` for a GREASE offer, which has nothing to seal.
+    ///
+    /// The state is built anyway, because sizing the random payload like a
+    /// real inner hello is the whole point of the exercise; it just never
+    /// encrypts one.
+    sender: Option<Box<dyn HpkeSealer>>,
     // The ID of the ECH configuration we've chosen - this is included in the outer ECH extension.
     config_id: u8,
     // The private server name we'll use for the inner protected hello.
@@ -355,6 +458,54 @@ impl EchState {
             &HpkePublicKey(key_config.public_key.0.clone()),
         )?;
 
+        Self::assemble(
+            config_contents,
+            config.suite.suite().sym,
+            enc,
+            Some(sender),
+            inner_name,
+            client_auth_enabled,
+            secure_random,
+            enable_sni,
+        )
+    }
+
+    /// State for a GREASE offer.
+    ///
+    /// Takes the encapsulated key rather than producing one: GREASE addresses
+    /// nobody, so there is nothing to encapsulate to and no provider needed to
+    /// do it with.
+    pub(crate) fn grease(
+        config_contents: &EchConfigContents,
+        cipher_suite: HpkeSymmetricCipherSuite,
+        enc: EncapsulatedSecret,
+        inner_name: ServerName<'static>,
+        secure_random: &'static dyn SecureRandom,
+        enable_sni: bool,
+    ) -> Result<Self, Error> {
+        Self::assemble(
+            config_contents,
+            cipher_suite,
+            enc,
+            None,
+            inner_name,
+            false,
+            secure_random,
+            enable_sni,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn assemble(
+        config_contents: &EchConfigContents,
+        cipher_suite: HpkeSymmetricCipherSuite,
+        enc: EncapsulatedSecret,
+        sender: Option<Box<dyn HpkeSealer>>,
+        inner_name: ServerName<'static>,
+        client_auth_enabled: bool,
+        secure_random: &'static dyn SecureRandom,
+        enable_sni: bool,
+    ) -> Result<Self, Error> {
         // Start a new transcript buffer for the inner hello.
         let mut inner_hello_transcript = HandshakeHashBuffer::new();
         if client_auth_enabled {
@@ -364,11 +515,11 @@ impl EchState {
         Ok(Self {
             secure_random,
             sender,
-            config_id: key_config.config_id,
+            config_id: config_contents.key_config.config_id,
             inner_name,
             outer_name: config_contents.public_name.clone(),
             maximum_name_length: config_contents.maximum_name_length,
-            cipher_suite: config.suite.suite().sym,
+            cipher_suite,
             enc,
             inner_hello_random: Random::new(secure_random)?,
             inner_hello_transcript,
@@ -442,6 +593,12 @@ impl EchState {
         // Next we compute the proper extension payload.
         let payload = self
             .sender
+            .as_mut()
+            // A state without a sealer exists only to size a GREASE payload,
+            // and GREASE never reaches this path.
+            .ok_or(Error::General(
+                "ECH offer attempted without a sealer".into(),
+            ))?
             .seal(&outer_hello.get_encoding(), &encoded_inner_hello)?;
 
         // And then we replace the placeholder extension with the real one.

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -16,7 +16,7 @@ use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU16};
 use crate::msgs::codec::{Codec, Reader};
-use crate::msgs::enums::{ExtensionType, HpkeKem};
+use crate::msgs::enums::ExtensionType;
 use crate::msgs::handshake::{
     ClientExtensions, ClientHelloPayload, EchConfigContents, EchConfigPayload, Encoding,
     EncryptedClientHello, EncryptedClientHelloOuter, HandshakeMessagePayload, HandshakePayload,
@@ -330,7 +330,7 @@ impl EchGreaseConfig {
         // `enable_sni` is false either way: the inner hello is never sent, it
         // exists only so the payload below is the length a real one would be.
         let mut grease_state = match (self.hpke, &self.placeholder_key) {
-            (Some(hpke), Some(placeholder_key)) => EchState::new(
+            (Some(hpke), Some(_)) => EchState::new(
                 &EchConfig {
                     config: EchConfigPayload::V18(contents),
                     suite: hpke,
@@ -1000,7 +1000,7 @@ mod tests {
 
     use super::*;
     use crate::enums::CipherSuite;
-    use crate::msgs::enums::{Compression, HpkeAead, HpkeKdf};
+    use crate::msgs::enums::{Compression, HpkeAead, HpkeKdf, HpkeKem};
     use crate::msgs::handshake::{Random, ServerExtensions, SessionId};
 
     #[test]

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -16,6 +16,7 @@ use crate::bs_debug;
 use crate::check::inappropriate_handshake_message;
 use crate::client::client_conn::ClientConnectionData;
 use crate::client::common::ClientHelloDetails;
+use crate::client::client_hello_profile::Grease;
 use crate::client::ech::EchState;
 use crate::client::{ClientConfig, EchMode, EchStatus, tls13};
 use crate::common_state::{CommonState, HandshakeKind, KxState, State};
@@ -33,8 +34,9 @@ use crate::msgs::enums::{Compression, ExtensionType, NamedGroup};
 use crate::msgs::handshake::{
     CertificateStatusRequest, ClientExtensions, ClientExtensionsInput, ClientHelloPayload,
     ClientSessionTicket, EncryptedClientHello, HandshakeMessagePayload, HandshakePayload,
-    HelloRetryRequest, KeyShareEntry, ProtocolName, PskKeyExchangeModes, Random, ServerNamePayload,
-    SessionId, SupportedEcPointFormats, SupportedProtocolVersions, TransportParameters,
+    HelloRetryRequest, KeyShareEntry, ProtocolName, PskKeyExchangeModes, Random, RawExtension,
+    ServerNamePayload, SessionId, SupportedEcPointFormats, SupportedProtocolVersions,
+    TransportParameters,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -129,12 +131,18 @@ where
     let random = Random::new(config.provider.secure_random)?;
     let extension_order_seed = crate::rand::random_u16(config.provider.secure_random)?;
 
+    let grease = match config.client_hello_profile.grease {
+        true => Some(Grease::new(config.provider.secure_random)?),
+        false => None,
+    };
+
     let hello = ClientHelloDetails::new(
         extra_exts
             .protocols
             .clone()
             .unwrap_or_default(),
         extension_order_seed,
+        grease,
     );
 
     let ech_state = match config.ech_mode.as_ref() {
@@ -236,9 +244,10 @@ where
     // builder semantics.
     let forbids_tls12 = cx.common.is_quic() || ech_state.is_some();
 
-    let supported_versions = SupportedProtocolVersions {
+    let mut supported_versions = SupportedProtocolVersions {
         tls12: config.supports_version(ProtocolVersion::TLSv1_2) && !forbids_tls12,
         tls13: config.supports_version(ProtocolVersion::TLSv1_3),
+        grease: None,
     };
 
     // should be unreachable thanks to config builder
@@ -396,19 +405,77 @@ where
     // but they also need to keep the same order as the previous ClientHello
     exts.order_seed = input.hello.extension_order_seed;
 
-    let mut cipher_suites: Vec<_> = config
-        .provider
-        .cipher_suites
-        .iter()
-        .filter_map(|cs| match cs.usable_for_protocol(cx.common.protocol) {
-            true => Some(cs.suite()),
-            false => None,
-        })
-        .collect();
+    let profile = &config.client_hello_profile;
 
-    if supported_versions.tls12 {
-        // We don't do renegotiation at all, in fact.
-        cipher_suites.push(CipherSuite::TLS_EMPTY_RENEGOTIATION_INFO_SCSV);
+    let mut cipher_suites: Vec<_> = match &profile.cipher_suites {
+        // The caller owns the whole list, signalling value included: an
+        // implementation being imitated that sends the renegotiation_info
+        // extension rather than the SCSV would be given away by us adding one.
+        Some(suites) => suites
+            .iter()
+            .copied()
+            .map(CipherSuite::from)
+            .collect(),
+        None => {
+            let mut suites: Vec<_> = config
+                .provider
+                .cipher_suites
+                .iter()
+                .filter_map(|cs| match cs.usable_for_protocol(cx.common.protocol) {
+                    true => Some(cs.suite()),
+                    false => None,
+                })
+                .collect();
+
+            if supported_versions.tls12 {
+                // We don't do renegotiation at all, in fact.
+                suites.push(CipherSuite::TLS_EMPTY_RENEGOTIATION_INFO_SCSV);
+            }
+            suites
+        }
+    };
+
+    // Shape the hello per the configured profile.
+    //
+    // This is deliberately the last thing done to the lists: GREASE goes in
+    // front of what rustls decided, and rustls decides nothing on the basis of
+    // it. A peer that reads any of these values as meaningful is broken in
+    // exactly the way RFC 8701 exists to expose.
+    if let Some(grease) = input.hello.grease {
+        cipher_suites.insert(0, CipherSuite::from(grease.cipher_suite));
+
+        if let Some(groups) = exts.named_groups.as_mut() {
+            groups.insert(0, NamedGroup::from(grease.named_group));
+        }
+
+        if let Some(shares) = exts.key_shares.as_mut() {
+            shares.insert(
+                0,
+                KeyShareEntry::new(
+                    NamedGroup::from(grease.named_group),
+                    Grease::KEY_SHARE_PAYLOAD,
+                ),
+            );
+        }
+
+        supported_versions.grease = Some(grease.version);
+        exts.supported_versions = Some(supported_versions);
+
+        exts.prepended_extensions
+            .push(RawExtension::empty(grease.first_extension));
+    }
+
+    exts.prepended_extensions
+        .extend(profile.prepend_extensions.iter().cloned());
+    exts.appended_extensions
+        .extend(profile.append_extensions.iter().cloned());
+
+    if let Some(grease) = input.hello.grease {
+        exts.appended_extensions
+            .push(RawExtension {
+                typ: grease.last_extension,
+                payload: Grease::LAST_EXTENSION_PAYLOAD.to_vec(),
+            });
     }
 
     let mut chp_payload = ClientHelloPayload {
@@ -460,8 +527,26 @@ where
         _ => {}
     }
 
+    // Pad the hello last of all.
+    //
+    // Later steps only ever fill in bytes that are already counted: the PSK
+    // binder is a placeholder of its final size by now, and Reality writes
+    // into the session id, which is fixed width. So the length measured here
+    // is the length that goes on the wire.
+    if let Some(padding) = profile.padding {
+        let mut measured = Vec::new();
+        chp_payload.encode(&mut measured);
+
+        if let Some(body_len) = padding.body_len(measured.len()) {
+            chp_payload
+                .extensions
+                .appended_extensions
+                .push(RawExtension::padding(body_len));
+        }
+    }
+
     // Note what extensions we sent.
-    input.hello.sent_extensions = chp_payload.collect_used();
+    input.hello.sent_extensions = chp_payload.all_sent_extensions();
 
     let mut chp = HandshakeMessagePayload(HandshakePayload::ClientHello(chp_payload));
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -15,8 +15,8 @@ use crate::SupportedCipherSuite;
 use crate::bs_debug;
 use crate::check::inappropriate_handshake_message;
 use crate::client::client_conn::ClientConnectionData;
-use crate::client::common::ClientHelloDetails;
 use crate::client::client_hello_profile::Grease;
+use crate::client::common::ClientHelloDetails;
 use crate::client::ech::EchState;
 use crate::client::{ClientConfig, EchMode, EchStatus, tls13};
 use crate::common_state::{CommonState, HandshakeKind, KxState, State};
@@ -47,7 +47,6 @@ use crate::verify::ServerCertVerifier;
 pub(super) type NextState<'a> = Box<dyn State<ClientConnectionData> + 'a>;
 pub(super) type NextStateOrError<'a> = Result<NextState<'a>, Error>;
 pub(super) type ClientContext<'a> = crate::common_state::Context<'a, ClientConnectionData>;
-
 
 pub(super) fn start_handshake<T>(
     server_name: ServerName<'static>,
@@ -146,9 +145,7 @@ where
     );
 
     let ech_state = match config.ech_mode.as_ref() {
-        Some(EchMode::Enable(ech_config)) => {
-            Some(ech_config.state(server_name.clone(), &config)?)
-        }
+        Some(EchMode::Enable(ech_config)) => Some(ech_config.state(server_name.clone(), &config)?),
         _ => None,
     };
 
@@ -174,7 +171,6 @@ where
         reality_state,
     )
 }
-
 
 struct ExpectServerHello {
     input: ClientHelloInput,
@@ -465,10 +461,18 @@ where
             .push(RawExtension::empty(grease.first_extension));
     }
 
-    exts.prepended_extensions
-        .extend(profile.prepend_extensions.iter().cloned());
-    exts.appended_extensions
-        .extend(profile.append_extensions.iter().cloned());
+    exts.prepended_extensions.extend(
+        profile
+            .prepend_extensions
+            .iter()
+            .cloned(),
+    );
+    exts.appended_extensions.extend(
+        profile
+            .append_extensions
+            .iter()
+            .cloned(),
+    );
 
     if let Some(grease) = input.hello.grease {
         exts.appended_extensions

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -768,11 +768,8 @@ fn test_reality_session_id_not_overwritten_by_session_id_generator() {
     let ch_reality_only = client_hello_sent_for_config(config.clone()).unwrap();
 
     // Get ClientHello with Reality + a session_id_generator that would produce all-0xFF
-    let ch_reality_with_generator = client_hello_sent_with_session_id_generator(
-        config,
-        |_| [0xFF; 32],
-    )
-    .unwrap();
+    let ch_reality_with_generator =
+        client_hello_sent_with_session_id_generator(config, |_| [0xFF; 32]).unwrap();
 
     // Reality session_id should NOT be all zeros (it's encrypted data)
     assert_ne!(ch_reality_only.session_id.data, [0u8; 32]);
@@ -780,13 +777,20 @@ fn test_reality_session_id_not_overwritten_by_session_id_generator() {
     // With both Reality and session_id_generator, the session_id should come from
     // Reality (not the generator's all-0xFF value)
     assert_ne!(
-        ch_reality_with_generator.session_id.data,
+        ch_reality_with_generator
+            .session_id
+            .data,
         [0xFF; 32],
         "session_id_generator should not overwrite Reality's session_id"
     );
 
     // The session_id should still be non-zero (Reality-computed)
-    assert_ne!(ch_reality_with_generator.session_id.data, [0u8; 32]);
+    assert_ne!(
+        ch_reality_with_generator
+            .session_id
+            .data,
+        [0u8; 32]
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -869,7 +873,10 @@ impl WireClientHello {
             extensions.push((typ, body[at..at + len].to_vec()));
             at += len;
         }
-        assert_eq!(at, exts_end, "extension list length disagrees with contents");
+        assert_eq!(
+            at, exts_end,
+            "extension list length disagrees with contents"
+        );
         assert_eq!(at, body.len(), "trailing bytes after the extension list");
 
         Self {
@@ -906,7 +913,9 @@ impl WireClientHello {
 
     /// key_share(51): a u16 length, then entries of group, u16 length, body.
     fn key_shares(&self) -> Vec<(u16, Vec<u8>)> {
-        let body = self.extension(51).expect("no key_share");
+        let body = self
+            .extension(51)
+            .expect("no key_share");
         let mut at = 2;
         let mut out = Vec::new();
         while at < body.len() {
@@ -1201,9 +1210,7 @@ fn a_dictated_cipher_list_does_not_get_the_scsv_appended() {
 
     assert_eq!(hello.cipher_suites, vec![0x1301, 0x1302, 0x1303]);
     assert!(
-        !hello
-            .cipher_suites
-            .contains(&0x00ff),
+        !hello.cipher_suites.contains(&0x00ff),
         "TLS_EMPTY_RENEGOTIATION_INFO_SCSV added behind the caller's back"
     );
 }
@@ -1216,9 +1223,7 @@ fn the_default_cipher_list_still_carries_the_scsv() {
     let hello = WireClientHello::capture(client_config_with_profile(Default::default()));
 
     assert!(
-        hello
-            .cipher_suites
-            .contains(&0x00ff),
+        hello.cipher_suites.contains(&0x00ff),
         "suites: {:04x?}",
         hello.cipher_suites
     );

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -788,3 +788,453 @@ fn test_reality_session_id_not_overwritten_by_session_id_generator() {
     // The session_id should still be non-zero (Reality-computed)
     assert_ne!(ch_reality_with_generator.session_id.data, [0u8; 32]);
 }
+
+// ---------------------------------------------------------------------------
+// ClientHello shaping
+//
+// These read the bytes that actually left, not the parsed structure: parsing
+// throws away exactly what is under test here - GREASE, extensions rustls does
+// not model, and the order everything went out in.
+
+/// A `ClientHello` as it went on the wire.
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+struct WireClientHello {
+    /// Handshake message body, without the four byte header.
+    body: Vec<u8>,
+    cipher_suites: Vec<u16>,
+    /// Extensions in the order they were written, unknown ones included.
+    extensions: Vec<(u16, Vec<u8>)>,
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+impl WireClientHello {
+    fn capture(config: ClientConfig) -> Self {
+        let mut conn =
+            ClientConnection::new(config.into(), ServerName::try_from("localhost").unwrap())
+                .unwrap();
+        let mut bytes = Vec::new();
+        conn.write_tls(&mut bytes).unwrap();
+
+        // Whatever we did to the hello, it must still be a hello. Reading it
+        // back with rustls own parser is the cheapest way to be sure every
+        // length field still agrees with its contents.
+        let message = OutboundOpaqueMessage::read(&mut Reader::init(&bytes))
+            .unwrap()
+            .into_plain_message();
+        match Message::try_from(message).unwrap() {
+            Message {
+                payload:
+                    MessagePayload::Handshake {
+                        parsed: HandshakeMessagePayload(HandshakePayload::ClientHello(_)),
+                        ..
+                    },
+                ..
+            } => {}
+            other => panic!("unexpected message {other:?}"),
+        }
+
+        Self::parse(&bytes)
+    }
+
+    fn parse(record: &[u8]) -> Self {
+        let record_len = u16::from_be_bytes([record[3], record[4]]) as usize;
+        let handshake = &record[5..5 + record_len];
+        assert_eq!(handshake[0], 0x01, "not a ClientHello");
+
+        let hs_len = u32::from_be_bytes([0, handshake[1], handshake[2], handshake[3]]) as usize;
+        let body = handshake[4..4 + hs_len].to_vec();
+
+        let mut at = 2 + 32; // legacy_version, random
+        at += 1 + body[at] as usize; // legacy_session_id
+
+        let suites_len = u16::from_be_bytes([body[at], body[at + 1]]) as usize;
+        at += 2;
+        let cipher_suites = body[at..at + suites_len]
+            .chunks_exact(2)
+            .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+            .collect();
+        at += suites_len;
+
+        at += 1 + body[at] as usize; // legacy_compression_methods
+
+        let exts_len = u16::from_be_bytes([body[at], body[at + 1]]) as usize;
+        at += 2;
+        let exts_end = at + exts_len;
+
+        let mut extensions = Vec::new();
+        while at < exts_end {
+            let typ = u16::from_be_bytes([body[at], body[at + 1]]);
+            let len = u16::from_be_bytes([body[at + 2], body[at + 3]]) as usize;
+            at += 4;
+            extensions.push((typ, body[at..at + len].to_vec()));
+            at += len;
+        }
+        assert_eq!(at, exts_end, "extension list length disagrees with contents");
+        assert_eq!(at, body.len(), "trailing bytes after the extension list");
+
+        Self {
+            body,
+            cipher_suites,
+            extensions,
+        }
+    }
+
+    fn extension_types(&self) -> Vec<u16> {
+        self.extensions
+            .iter()
+            .map(|(typ, _)| *typ)
+            .collect()
+    }
+
+    fn extension(&self, typ: u16) -> Option<&[u8]> {
+        self.extensions
+            .iter()
+            .find(|(t, _)| *t == typ)
+            .map(|(_, body)| body.as_slice())
+    }
+
+    /// supported_groups(10): a u16 length, then u16 group ids.
+    fn named_groups(&self) -> Vec<u16> {
+        let body = self
+            .extension(10)
+            .expect("no supported_groups");
+        body[2..]
+            .chunks_exact(2)
+            .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+            .collect()
+    }
+
+    /// key_share(51): a u16 length, then entries of group, u16 length, body.
+    fn key_shares(&self) -> Vec<(u16, Vec<u8>)> {
+        let body = self.extension(51).expect("no key_share");
+        let mut at = 2;
+        let mut out = Vec::new();
+        while at < body.len() {
+            let group = u16::from_be_bytes([body[at], body[at + 1]]);
+            let len = u16::from_be_bytes([body[at + 2], body[at + 3]]) as usize;
+            at += 4;
+            out.push((group, body[at..at + len].to_vec()));
+            at += len;
+        }
+        out
+    }
+
+    /// supported_versions(43): a u8 length, then u16 versions.
+    fn versions(&self) -> Vec<u16> {
+        let body = self
+            .extension(43)
+            .expect("no supported_versions");
+        body[1..]
+            .chunks_exact(2)
+            .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+            .collect()
+    }
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+fn is_grease(value: u16) -> bool {
+    let [high, low] = value.to_be_bytes();
+    high == low && low & 0x0f == 0x0a
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+fn client_config_with_profile(profile: crate::client::ClientHelloProfile) -> ClientConfig {
+    #[cfg(feature = "ring")]
+    let provider = crate::crypto::ring::default_provider();
+    #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+    let provider = crate::crypto::aws_lc_rs::default_provider();
+
+    let mut config = ClientConfig::builder_with_provider(provider.into())
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(roots())
+        .with_no_client_auth();
+    config.client_hello_profile = Arc::new(profile);
+    config
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn default_profile_changes_nothing() {
+    let hello = WireClientHello::capture(client_config_with_profile(Default::default()));
+
+    assert!(
+        !hello
+            .cipher_suites
+            .iter()
+            .copied()
+            .any(is_grease),
+        "cipher suites: {:04x?}",
+        hello.cipher_suites
+    );
+    assert!(
+        !hello
+            .extension_types()
+            .into_iter()
+            .any(is_grease),
+        "extensions: {:04x?}",
+        hello.extension_types()
+    );
+    assert!(
+        !hello
+            .named_groups()
+            .into_iter()
+            .any(is_grease)
+    );
+    assert!(hello.extension(21).is_none(), "unasked-for padding");
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn grease_reaches_every_list_that_browsers_grease() {
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            grease: true,
+            ..Default::default()
+        },
+    ));
+
+    // Always first in its list: a peer that reads the list in order and gives
+    // up on the first value it does not know is caught by the next connection
+    // rather than years later.
+    assert!(
+        is_grease(hello.cipher_suites[0]),
+        "cipher suites: {:04x?}",
+        hello.cipher_suites
+    );
+    assert!(
+        is_grease(hello.named_groups()[0]),
+        "groups: {:04x?}",
+        hello.named_groups()
+    );
+    assert!(
+        is_grease(hello.versions()[0]),
+        "versions: {:04x?}",
+        hello.versions()
+    );
+
+    let key_shares = hello.key_shares();
+    assert!(is_grease(key_shares[0].0));
+    assert_eq!(
+        key_shares[0].1,
+        vec![0x00],
+        "the GREASE key share is one zero byte, as BoringSSL sends it"
+    );
+
+    // And what rustls meant to send is still behind it.
+    assert!(
+        hello.cipher_suites[1..]
+            .iter()
+            .copied()
+            .any(|suite| !is_grease(suite))
+    );
+    assert!(key_shares.len() > 1, "GREASE displaced the real key share");
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn grease_extensions_bracket_the_list() {
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            grease: true,
+            ..Default::default()
+        },
+    ));
+
+    let types = hello.extension_types();
+    let grease: Vec<u16> = types
+        .iter()
+        .copied()
+        .filter(|typ| is_grease(*typ))
+        .collect();
+
+    assert_eq!(grease.len(), 2, "extensions: {types:04x?}");
+    assert_ne!(
+        grease[0], grease[1],
+        "two extensions of one type is a protocol error"
+    );
+    assert!(is_grease(types[0]), "first extension: {:04x}", types[0]);
+    assert!(
+        is_grease(*types.last().unwrap()),
+        "last extension: {:04x}",
+        types.last().unwrap()
+    );
+
+    assert_eq!(hello.extension(grease[0]), Some(&[][..]));
+    assert_eq!(hello.extension(grease[1]), Some(&[0x00][..]));
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn verbatim_extensions_go_where_they_were_put() {
+    use crate::msgs::handshake::RawExtension;
+
+    // signed_certificate_timestamp and ALPS: two extensions rustls has no
+    // reason to model, and two no browser omits.
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            prepend_extensions: vec![RawExtension::empty(0x0012)],
+            append_extensions: vec![RawExtension {
+                typ: 0x4469,
+                payload: b"\x00\x03\x02h2".to_vec(),
+            }],
+            ..Default::default()
+        },
+    ));
+
+    let types = hello.extension_types();
+    assert_eq!(types[0], 0x0012, "extensions: {types:04x?}");
+    assert_eq!(*types.last().unwrap(), 0x4469);
+
+    assert_eq!(hello.extension(0x0012), Some(&[][..]));
+    assert_eq!(hello.extension(0x4469), Some(&b"\x00\x03\x02h2"[..]));
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn padding_brings_the_hello_to_the_target_length() {
+    use crate::client::Padding;
+
+    // A window wide enough that the hello lands inside it whatever rustls
+    // decides to send. The rule itself is unit tested; what matters here is
+    // that the arithmetic agrees with the bytes.
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            padding: Some(Padding {
+                only_above: 0,
+                up_to: 1024,
+            }),
+            ..Default::default()
+        },
+    ));
+
+    assert_eq!(hello.body.len(), 1024);
+    assert_eq!(*hello.extension_types().last().unwrap(), 21);
+    assert!(
+        hello
+            .extension(21)
+            .unwrap()
+            .iter()
+            .all(|byte| *byte == 0)
+    );
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn padding_stays_out_of_a_hello_already_long_enough() {
+    use crate::client::Padding;
+
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            padding: Some(Padding {
+                only_above: 0,
+                up_to: 16,
+            }),
+            ..Default::default()
+        },
+    ));
+
+    assert!(hello.body.len() > 16);
+    assert!(hello.extension(21).is_none());
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn padding_counts_the_grease_and_verbatim_extensions_too() {
+    use crate::client::Padding;
+    use crate::msgs::handshake::RawExtension;
+
+    // Padding is measured last, so everything else has to be in place by then.
+    // Get that order wrong and the hello comes out short by the size of the
+    // other extensions - which is the length signal padding exists to erase.
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            grease: true,
+            append_extensions: vec![RawExtension {
+                typ: 0x4469,
+                payload: vec![0xab; 64],
+            }],
+            padding: Some(Padding {
+                only_above: 0,
+                up_to: 1024,
+            }),
+            ..Default::default()
+        },
+    ));
+
+    assert_eq!(hello.body.len(), 1024);
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn the_cipher_suite_list_can_be_dictated() {
+    // Chrome's list, GREASE aside. The last four are static RSA key exchange,
+    // which rustls does not implement and will never negotiate - they are here
+    // to be counted by whoever is looking, and for no other reason.
+    let chrome = vec![
+        0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0x009c, 0x009d,
+        0x002f, 0x0035,
+    ];
+
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            cipher_suites: Some(chrome.clone()),
+            ..Default::default()
+        },
+    ));
+
+    assert_eq!(hello.cipher_suites, chrome);
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn a_dictated_cipher_list_does_not_get_the_scsv_appended() {
+    // rustls signals "no renegotiation" with the SCSV; browsers use the
+    // renegotiation_info extension instead. An extra pseudo-suite in the list
+    // is as visible as any real one, so the caller's list has to be final.
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            cipher_suites: Some(vec![0x1301, 0x1302, 0x1303]),
+            ..Default::default()
+        },
+    ));
+
+    assert_eq!(hello.cipher_suites, vec![0x1301, 0x1302, 0x1303]);
+    assert!(
+        !hello
+            .cipher_suites
+            .contains(&0x00ff),
+        "TLS_EMPTY_RENEGOTIATION_INFO_SCSV added behind the caller's back"
+    );
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn the_default_cipher_list_still_carries_the_scsv() {
+    // The flip side of the test above: leaving the profile alone must not
+    // quietly change what rustls has always sent.
+    let hello = WireClientHello::capture(client_config_with_profile(Default::default()));
+
+    assert!(
+        hello
+            .cipher_suites
+            .contains(&0x00ff),
+        "suites: {:04x?}",
+        hello.cipher_suites
+    );
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn grease_goes_in_front_of_a_dictated_cipher_list_too() {
+    let hello = WireClientHello::capture(client_config_with_profile(
+        crate::client::ClientHelloProfile {
+            grease: true,
+            cipher_suites: Some(vec![0x1301, 0x1302]),
+            ..Default::default()
+        },
+    ));
+
+    assert!(is_grease(hello.cipher_suites[0]));
+    assert_eq!(hello.cipher_suites[1..], [0x1301, 0x1302]);
+}

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -1243,3 +1243,75 @@ fn grease_goes_in_front_of_a_dictated_cipher_list_too() {
     assert!(is_grease(hello.cipher_suites[0]));
     assert_eq!(hello.cipher_suites[1..], [0x1301, 0x1302]);
 }
+
+#[cfg(feature = "aws_lc_rs")]
+#[test]
+fn grease_ech_carries_the_kem_of_the_suite_it_was_given() {
+    use crate::client::{EchGreaseConfig, EchMode};
+    use crate::crypto::aws_lc_rs::hpke::{
+        DH_KEM_P256_HKDF_SHA256_AES_128, DH_KEM_X25519_HKDF_SHA256_AES_128,
+    };
+    use crate::crypto::hpke::Hpke;
+
+    // The `enc` field carries an ephemeral public key, and its length is the
+    // KEM's own: 32 bytes for X25519, 65 for an uncompressed P-256 point.
+    // GREASE that always claims P-256 no matter which suite it was handed is
+    // distinguishable from a client that GREASEs with X25519 - which is what
+    // browsers do, and the whole point of GREASE is to be indistinguishable.
+    for (suite, enc_len) in [
+        (DH_KEM_X25519_HKDF_SHA256_AES_128 as &'static dyn Hpke, 32),
+        (DH_KEM_P256_HKDF_SHA256_AES_128 as &'static dyn Hpke, 65),
+    ] {
+        let (public_key, _) = suite.generate_key_pair().unwrap();
+
+        let config = ClientConfig::builder_with_provider(
+            crate::crypto::aws_lc_rs::default_provider().into(),
+        )
+        .with_ech(EchMode::Grease(EchGreaseConfig::new(suite, public_key)))
+        .unwrap()
+        .with_root_certificates(roots())
+        .with_no_client_auth();
+
+        let hello = WireClientHello::capture(config);
+        let body = hello
+            .extension(0xfe0d)
+            .expect("no encrypted_client_hello extension");
+
+        // 0x00 outer, kdf u16, aead u16, config_id u8, then enc as a
+        // length-prefixed payload.
+        assert_eq!(body[0], 0x00, "not an outer ECH");
+        assert_eq!(
+            u16::from_be_bytes([body[6], body[7]]) as usize,
+            enc_len,
+            "{:?}",
+            suite.suite().kem
+        );
+    }
+}
+
+#[cfg(feature = "aws_lc_rs")]
+#[test]
+fn grease_ech_does_not_drop_tls12_from_the_hello() {
+    use crate::client::{EchGreaseConfig, EchMode};
+    use crate::crypto::aws_lc_rs::hpke::DH_KEM_X25519_HKDF_SHA256_AES_128;
+    use crate::crypto::hpke::Hpke;
+
+    // Real ECH needs TLS 1.3 and says so by pinning the version. GREASE ECH
+    // negotiates nothing, so it has no such requirement - and a client that
+    // sends the placeholder extension while quietly dropping TLS 1.2 has
+    // changed the very thing it was trying to blend into.
+    let suite = DH_KEM_X25519_HKDF_SHA256_AES_128 as &'static dyn Hpke;
+    let (public_key, _) = suite.generate_key_pair().unwrap();
+
+    let config =
+        ClientConfig::builder_with_provider(crate::crypto::aws_lc_rs::default_provider().into())
+            .with_ech(EchMode::Grease(EchGreaseConfig::new(suite, public_key)))
+            .unwrap()
+            .with_root_certificates(roots())
+            .with_no_client_auth();
+
+    let hello = WireClientHello::capture(config);
+
+    assert!(hello.extension(0xfe0d).is_some(), "no GREASE ECH");
+    assert_eq!(hello.versions(), vec![0x0304, 0x0303]);
+}

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -1315,3 +1315,81 @@ fn grease_ech_does_not_drop_tls12_from_the_hello() {
     assert!(hello.extension(0xfe0d).is_some(), "no GREASE ECH");
     assert_eq!(hello.versions(), vec![0x0304, 0x0303]);
 }
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn grease_ech_needs_no_hpke_provider() {
+    use crate::client::{EchGreaseConfig, EchMode};
+    use crate::crypto::hpke::HpkeSuite;
+    use crate::msgs::enums::{HpkeAead, HpkeKdf, HpkeKem};
+    use crate::msgs::handshake::HpkeSymmetricCipherSuite;
+
+    // The suite browsers GREASE with. Nothing here has to be implemented by
+    // the provider - the payload is random and the encapsulated key addresses
+    // nobody - which is the point: `ring` ships no HPKE, and `ring` is what
+    // every MIPS and embedded build uses.
+    let suite = HpkeSuite {
+        kem: HpkeKem::DHKEM_X25519_HKDF_SHA256,
+        sym: HpkeSymmetricCipherSuite {
+            kdf_id: HpkeKdf::HKDF_SHA256,
+            aead_id: HpkeAead::AES_128_GCM,
+        },
+    };
+
+    #[cfg(feature = "ring")]
+    let provider = crate::crypto::ring::default_provider();
+    #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+    let provider = crate::crypto::aws_lc_rs::default_provider();
+
+    let config = ClientConfig::builder_with_provider(provider.into())
+        .with_ech(EchMode::Grease(
+            EchGreaseConfig::without_provider(suite).unwrap(),
+        ))
+        .unwrap()
+        .with_root_certificates(roots())
+        .with_no_client_auth();
+
+    let hello = WireClientHello::capture(config);
+    let body = hello
+        .extension(0xfe0d)
+        .expect("no encrypted_client_hello");
+
+    // 0x00 outer, kdf u16, aead u16, config_id u8, then the encapsulated key
+    // as a length-prefixed payload. X25519 keys are 32 bytes, and a GREASE
+    // value of any other length would be the one thing a placeholder must not
+    // be: distinguishable.
+    assert_eq!(body[0], 0x00, "not an outer ECH");
+    assert_eq!(u16::from_be_bytes([body[1], body[2]]), 0x0001, "kdf");
+    assert_eq!(u16::from_be_bytes([body[3], body[4]]), 0x0001, "aead");
+    assert_eq!(u16::from_be_bytes([body[6], body[7]]), 32, "enc length");
+
+    // And the payload is sized like a real sealed inner hello: long enough to
+    // be one, and not a round number that would give it away.
+    let enc_end = 8 + 32;
+    let payload_len = u16::from_be_bytes([body[enc_end], body[enc_end + 1]]);
+    assert!(
+        payload_len > 64,
+        "payload of {payload_len} bytes is too short to pass"
+    );
+}
+
+#[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[test]
+fn grease_ech_refuses_a_kem_it_cannot_size() {
+    use crate::client::EchGreaseConfig;
+    use crate::crypto::hpke::HpkeSuite;
+    use crate::msgs::enums::{HpkeAead, HpkeKdf, HpkeKem};
+    use crate::msgs::handshake::HpkeSymmetricCipherSuite;
+
+    // Guessing a length would produce an encapsulated key of the wrong size,
+    // which is worse than declining: it looks like a client that does not know
+    // its own KEM.
+    let suite = HpkeSuite {
+        kem: HpkeKem::Unknown(0x1234),
+        sym: HpkeSymmetricCipherSuite {
+            kdf_id: HpkeKdf::HKDF_SHA256,
+            aead_id: HpkeAead::AES_128_GCM,
+        },
+    };
+    assert!(EchGreaseConfig::without_provider(suite).is_err());
+}

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -560,7 +560,7 @@ pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;
 pub use crate::msgs::enums::NamedGroup;
 pub use crate::msgs::ffdhe_groups;
-pub use crate::msgs::handshake::DistinguishedName;
+pub use crate::msgs::handshake::{DistinguishedName, RawExtension};
 #[cfg(feature = "std")]
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
@@ -581,6 +581,7 @@ pub use crate::webpki::RootCertStore;
 pub mod client {
     pub(super) mod builder;
     mod client_conn;
+    mod client_hello_profile;
     mod common;
     mod ech;
     pub(super) mod handy;
@@ -593,6 +594,7 @@ pub mod client {
     mod tls13;
 
     pub use builder::WantsClientCert;
+    pub use client_hello_profile::{ClientHelloProfile, Padding};
     pub use client_conn::{
         ClientConfig, ClientConnectionData, ClientSessionStore, EarlyDataError, ResolvesClientCert,
         Resumption, Tls12Resumption, UnbufferedClientConnection,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -594,13 +594,13 @@ pub mod client {
     mod tls13;
 
     pub use builder::WantsClientCert;
-    pub use client_hello_profile::{ClientHelloProfile, Padding};
     pub use client_conn::{
         ClientConfig, ClientConnectionData, ClientSessionStore, EarlyDataError, ResolvesClientCert,
         Resumption, Tls12Resumption, UnbufferedClientConnection,
     };
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};
+    pub use client_hello_profile::{ClientHelloProfile, Padding};
     pub use ech::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
     pub use handy::AlwaysResolvesClientRawPublicKeys;
     #[cfg(any(feature = "std", feature = "hashbrown"))]

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -349,6 +349,25 @@ enum_builder! {
     }
 }
 
+impl HpkeKem {
+    /// Length of an encapsulated key, `Nenc` in [RFC 9180 section 7.1].
+    ///
+    /// `None` for a KEM this crate does not know, since its encapsulated keys
+    /// have no length we can state.
+    ///
+    /// [RFC 9180 section 7.1]: https://www.rfc-editor.org/rfc/rfc9180#section-7.1
+    pub(crate) fn encapsulated_key_len(&self) -> Option<usize> {
+        Some(match self {
+            Self::DHKEM_P256_HKDF_SHA256 => 65,
+            Self::DHKEM_P384_HKDF_SHA384 => 97,
+            Self::DHKEM_P521_HKDF_SHA512 => 133,
+            Self::DHKEM_X25519_HKDF_SHA256 => 32,
+            Self::DHKEM_X448_HKDF_SHA512 => 56,
+            Self::Unknown(_) => return None,
+        })
+    }
+}
+
 enum_builder! {
     /// The Key Derivation Function (`Kdf`) type for HPKE operations.
     /// Listed by IANA, as specified in [RFC 9180 Section 7.2]

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -877,11 +877,6 @@ impl RawExtension {
         }
     }
 
-    /// Bytes this extension takes on the wire, header included.
-    pub(crate) fn encoded_len(&self) -> usize {
-        4 + self.payload.len()
-    }
-
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.typ.encode(bytes);
         let body = LengthPrefixedBuffer::new(ListLength::U16, bytes);

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1161,9 +1161,7 @@ impl<'a> Codec<'a> for ClientExtensions<'a> {
         if generated.is_empty()
             && trailing.is_empty()
             && self.prepended_extensions.is_empty()
-            && self
-                .appended_extensions
-                .is_empty()
+            && self.appended_extensions.is_empty()
         {
             return;
         }
@@ -1453,8 +1451,6 @@ impl ClientHelloPayload {
             })
             .unwrap_or_default()
     }
-
-
 
     pub(crate) fn has_certificate_compression_extension_with_duplicates(&self) -> bool {
         if let Some(algs) = &self.certificate_compression_algorithms {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -698,6 +698,13 @@ impl TlsListElement for KeyShareEntry {
 pub(crate) struct SupportedProtocolVersions {
     pub(crate) tls13: bool,
     pub(crate) tls12: bool,
+
+    /// A GREASE value (RFC 8701) to advertise ahead of the real versions.
+    ///
+    /// Only ever set on the client side. A server MUST ignore versions it does
+    /// not know, so this is a probe that the peer does so - which is the whole
+    /// point of GREASE.
+    pub(crate) grease: Option<u16>,
 }
 
 impl SupportedProtocolVersions {
@@ -720,6 +727,9 @@ impl SupportedProtocolVersions {
 impl Codec<'_> for SupportedProtocolVersions {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let inner = LengthPrefixedBuffer::new(Self::LIST_LENGTH, bytes);
+        if let Some(grease) = self.grease {
+            ProtocolVersion::from(grease).encode(inner.buf);
+        }
         if self.tls13 {
             ProtocolVersion::TLSv1_3.encode(inner.buf);
         }
@@ -740,7 +750,11 @@ impl Codec<'_> for SupportedProtocolVersions {
             };
         }
 
-        Ok(Self { tls13, tls12 })
+        Ok(Self {
+            tls13,
+            tls12,
+            grease: None,
+        })
     }
 }
 
@@ -824,6 +838,55 @@ impl TransportParameters<'_> {
             Self::QuicDraft(v) => TransportParameters::QuicDraft(v.into_owned()),
             Self::Quic(v) => TransportParameters::Quic(v.into_owned()),
         }
+    }
+}
+
+/// An extension rustls does not model, carried verbatim in a `ClientHello`.
+///
+/// rustls emits the extensions rustls needs. A client that has to resemble
+/// some other implementation on the wire needs extensions rustls has no reason
+/// to support - ALPS, `signed_certificate_timestamp`, GREASE placeholders -
+/// and their bodies are fixed strings, not something worth modelling. Those go
+/// here: type and body are written out as given, and nothing in rustls looks
+/// at them.
+///
+/// Placement is decided by which list the extension is put in, see
+/// [`ClientHelloProfile`][crate::client::ClientHelloProfile].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawExtension {
+    /// Extension type, as it goes on the wire.
+    pub typ: u16,
+    /// Extension body, without the type and length header.
+    pub payload: Vec<u8>,
+}
+
+impl RawExtension {
+    /// An extension with an empty body, e.g. `signed_certificate_timestamp`.
+    pub fn empty(typ: u16) -> Self {
+        Self {
+            typ,
+            payload: Vec::new(),
+        }
+    }
+
+    /// A `padding` extension (RFC 7685) of `len` zero bytes.
+    pub fn padding(len: usize) -> Self {
+        Self {
+            typ: u16::from(ExtensionType::Padding),
+            payload: vec![0u8; len],
+        }
+    }
+
+    /// Bytes this extension takes on the wire, header included.
+    pub(crate) fn encoded_len(&self) -> usize {
+        4 + self.payload.len()
+    }
+
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.typ.encode(bytes);
+        let body = LengthPrefixedBuffer::new(ListLength::U16, bytes);
+        body.buf
+            .extend_from_slice(&self.payload);
     }
 }
 
@@ -933,6 +996,13 @@ extension_struct! {
 
         /// Extensions that must appear contiguously.
         pub(crate) contiguous_extensions: Vec<ExtensionType>,
+
+        /// Verbatim extensions written before everything rustls generates.
+        pub(crate) prepended_extensions: Vec<RawExtension>,
+
+        /// Verbatim extensions written after everything rustls generates,
+        /// but ahead of ECH and PSK - those two are required to be last.
+        pub(crate) appended_extensions: Vec<RawExtension>,
     }
 }
 
@@ -964,6 +1034,8 @@ impl ClientExtensions<'_> {
             encrypted_client_hello_outer,
             order_seed,
             contiguous_extensions,
+            prepended_extensions,
+            appended_extensions,
         } = self;
         ClientExtensions {
             server_name: server_name.map(|x| x.into_owned()),
@@ -991,13 +1063,30 @@ impl ClientExtensions<'_> {
             encrypted_client_hello_outer,
             order_seed,
             contiguous_extensions,
+            prepended_extensions,
+            appended_extensions,
         }
     }
 
     pub(crate) fn used_extensions_in_encoding_order(&self) -> Vec<ExtensionType> {
+        let mut exts = self.body_extensions_in_encoding_order();
+        exts.extend(self.trailing_extensions());
+        exts
+    }
+
+    /// Extensions rustls generates, in the order they are written.
+    ///
+    /// The ones which the standard pins to the end of the list are not here,
+    /// see [`Self::trailing_extensions`].
+    fn body_extensions_in_encoding_order(&self) -> Vec<ExtensionType> {
         let mut exts = self.order_insensitive_extensions_in_random_order();
         exts.extend(&self.contiguous_extensions);
+        exts
+    }
 
+    /// Extensions the standard requires to come last, in that order.
+    fn trailing_extensions(&self) -> Vec<ExtensionType> {
+        let mut exts = Vec::with_capacity(3);
         if self
             .encrypted_client_hello_outer
             .is_some()
@@ -1010,6 +1099,22 @@ impl ClientExtensions<'_> {
         if self.preshared_key_offer.is_some() {
             exts.push(ExtensionType::PreSharedKey);
         }
+        exts
+    }
+
+    /// Every extension type this hello carries, verbatim ones included.
+    ///
+    /// Used to spot extensions a server answers without being asked. Verbatim
+    /// extensions belong in it for the same reason the modelled ones do: the
+    /// client did send them, so an answer to one is not unsolicited.
+    pub(crate) fn all_sent_extensions(&self) -> Vec<ExtensionType> {
+        let mut exts = self.collect_used();
+        exts.extend(
+            self.prepended_extensions
+                .iter()
+                .chain(self.appended_extensions.iter())
+                .map(|raw| ExtensionType::from(raw.typ)),
+        );
         exts
     }
 
@@ -1050,14 +1155,30 @@ impl ClientExtensions<'_> {
 
 impl<'a> Codec<'a> for ClientExtensions<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        let order = self.used_extensions_in_encoding_order();
+        let generated = self.body_extensions_in_encoding_order();
+        let trailing = self.trailing_extensions();
 
-        if order.is_empty() {
+        if generated.is_empty()
+            && trailing.is_empty()
+            && self.prepended_extensions.is_empty()
+            && self
+                .appended_extensions
+                .is_empty()
+        {
             return;
         }
 
         let body = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        for item in order {
+        for raw in &self.prepended_extensions {
+            raw.encode(body.buf);
+        }
+        for item in generated {
+            self.encode_one(item, body.buf);
+        }
+        for raw in &self.appended_extensions {
+            raw.encode(body.buf);
+        }
+        for item in trailing {
             self.encode_one(item, body.buf);
         }
     }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -783,6 +783,7 @@ fn sample_client_hello_payload() -> ClientHelloPayload {
             named_groups: Some(vec![NamedGroup::X25519]),
             protocols: Some(vec![ProtocolName::from(vec![0])]),
             supported_versions: Some(SupportedProtocolVersions {
+                grease: None,
                 tls13: true,
                 ..Default::default()
             }),

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -357,6 +357,7 @@ fn minimal_client_hello() -> ClientHelloPayload {
             signature_schemes: Some(vec![SignatureScheme::RSA_PSS_SHA256]),
             named_groups: Some(vec![NamedGroup::X25519, NamedGroup::secp256r1]),
             supported_versions: Some(SupportedProtocolVersions {
+                grease: None,
                 tls12: true,
                 tls13: true,
             }),

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -8183,3 +8183,76 @@ impl ActiveKeyExchange for FakeHybridActive {
 }
 
 const CONFIDENTIALITY_LIMIT: u64 = 1024;
+
+mod client_hello_shaping {
+    use std::sync::Arc;
+
+    use rustls::client::{ClientHelloProfile, Padding};
+    use rustls::RawExtension;
+
+    use super::*;
+
+    /// A hello shaped to resemble a browser still has to be a hello.
+    ///
+    /// GREASE, extensions the peer has never heard of and a block of padding
+    /// are each individually ignorable by a correct server - this checks that
+    /// all of them together, on every version and key type, still get through.
+    #[test]
+    fn a_shaped_hello_completes_a_handshake() {
+        let provider = provider::default_provider();
+        for kt in KeyType::all_for_provider(&provider) {
+            for version in rustls::ALL_VERSIONS {
+                let mut client_config =
+                    make_client_config_with_versions(*kt, &[version], &provider);
+                client_config.client_hello_profile = Arc::new(ClientHelloProfile {
+                    grease: true,
+                    // signed_certificate_timestamp and ALPS: rustls models
+                    // neither, browsers send both.
+                    prepend_extensions: vec![RawExtension::empty(0x0012)],
+                    append_extensions: vec![RawExtension {
+                        typ: 0x4469,
+                        payload: b"\x00\x03\x02h2".to_vec(),
+                    }],
+                    padding: Some(Padding::default()),
+                    ..Default::default()
+                });
+
+                let (mut client, mut server) =
+                    make_pair_for_configs(client_config, make_server_config(*kt, &provider));
+                do_handshake(&mut client, &mut server);
+
+                assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+            }
+        }
+    }
+
+    /// Advertising suites rustls cannot negotiate is safe as long as the peer
+    /// still finds one it can.
+    ///
+    /// The last four here are static RSA key exchange, which rustls does not
+    /// implement. A rustls server will not pick them, which is the point: the
+    /// count and the order are visible to anyone fingerprinting the hello, and
+    /// nothing else changes.
+    #[test]
+    fn a_dictated_cipher_list_completes_a_handshake() {
+        let provider = provider::default_provider();
+        for kt in KeyType::all_for_provider(&provider) {
+            for version in rustls::ALL_VERSIONS {
+                let mut client_config =
+                    make_client_config_with_versions(*kt, &[version], &provider);
+                client_config.client_hello_profile = Arc::new(ClientHelloProfile {
+                    grease: true,
+                    cipher_suites: Some(vec![
+                        0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8,
+                        0x009c, 0x009d, 0x002f, 0x0035,
+                    ]),
+                    ..Default::default()
+                });
+
+                let (mut client, mut server) =
+                    make_pair_for_configs(client_config, make_server_config(*kt, &provider));
+                do_handshake(&mut client, &mut server);
+            }
+        }
+    }
+}

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -8187,8 +8187,8 @@ const CONFIDENTIALITY_LIMIT: u64 = 1024;
 mod client_hello_shaping {
     use std::sync::Arc;
 
-    use rustls::client::{ClientHelloProfile, Padding};
     use rustls::RawExtension;
+    use rustls::client::{ClientHelloProfile, Padding};
 
     use super::*;
 


### PR DESCRIPTION
## Why

clash-rs answers `client-fingerprint` in a VLESS or AnyTLS proxy with:

```
WARN clash-lib/src/proxy/converters/vless.rs:35:
client-fingerprint (uTLS) is not yet implemented, ignored for main-out
```

It has to, because there is nothing in rustls to answer it with. Reality connects and carries traffic, but the ClientHello it sends is recognisably rustls: no GREASE, no `signed_certificate_timestamp`, no ALPS, no padding, and a cipher list that is exactly the set rustls can negotiate. Any one of those is enough to separate it from a browser before a byte of application data moves — which is the one thing Reality is supposed to prevent.

This adds the parts of that job which belong in the TLS stack, and only those.

## What

`ClientConfig::client_hello_profile` carries a `ClientHelloProfile`:

| field | effect |
|---|---|
| `grease` | RFC 8701 values in the cipher list, supported groups, key shares, supported versions, plus two extensions — one leading and empty, one trailing with a zero byte, as BoringSSL emits them |
| `prepend_extensions` | verbatim extensions before everything rustls builds |
| `append_extensions` | and after it, ahead of the ECH and PSK extensions the standard pins to the end |
| `padding` | the BoringSSL rule by default: a hello landing in `[0x100, 0x200)` is padded out to `0x200` |
| `cipher_suites` | the list to put on the wire, in that order |

Which extensions a given browser sends, with what bodies, is deliberately **not** modelled here. That is the caller's knowledge, expressed through `RawExtension { typ, payload }`. rustls holds the mechanism; the browser table belongs in clash-rs.

Extension ordering needed no new machinery — `contiguous_extensions` and `order_seed` were already there.

## The one loaded gun

`cipher_suites` advertises suites the provider does not implement. If a peer selects one, the handshake fails. It is documented as such at the field.

It exists because the suite count and order feed every common fingerprint, and no browser's list is a subset of what rustls implements — static RSA key exchange being the obvious case. For a Reality client the risk is nil (TLS 1.3 is mandatory there); for a general client it is real, and the doc comment says so plainly.

## Defaults change nothing

With an untouched profile the hello is byte for byte what it was, `TLS_EMPTY_RENEGOTIATION_INFO_SCSV` included. There is a test asserting exactly that, because a "fingerprinting" feature that quietly alters every other connection would be a bad trade.

## Tests

Eighteen new ones. They read the bytes that actually left rather than the parsed `ClientHelloPayload`, since parsing discards precisely what is under test — GREASE, unmodelled extensions, and the order everything went out in.

- wire layout of each field, including the two GREASE extension bodies and the GREASE key share being a single zero byte
- the padding arithmetic against its edges, including the case four bytes short of the target where BoringSSL sends an empty extension and overshoots
- padding measured after GREASE and verbatim extensions, so it lands on the target rather than short of it
- **two end-to-end handshakes** — a fully shaped hello, and a dictated cipher list containing suites rustls cannot negotiate — across every version and key type

That last group is the one that matters: a hello that fingerprints well and fails to connect is worse than no change at all.

```
cargo test -p rustls --lib --test api --test ech --no-default-features --features aws_lc_rs,std,tls12,logging
test result: ok. 256 passed; 0 failed
test result: ok. 213 passed; 0 failed
```

## Three GREASE ECH fixes came out of the same work

Separate commits, all about the same thing - a placeholder that does not resemble the placeholders it hides among is not doing its job.

- **The KEM was fixed to P-256** regardless of the HPKE suite handed in. The KEM decides the length of `enc` (32 bytes for X25519, 65 for an uncompressed P-256 point) and that length is on the wire, so GREASEing with an X25519 suite emitted a P-256 sized key. Now it uses the suite's own KEM.
- **`with_ech` pinned TLS 1.3 for both modes.** Real ECH requires it; GREASE negotiates nothing and has no such requirement, so the pin cost the connection TLS 1.2 and changed the hello. Browsers offer both versions alongside the placeholder.
- **GREASE required a full HPKE implementation**, and rustls ships one only for aws-lc-rs. That rules out `ring` — which is what every MIPS and embedded build uses, aws-lc-rs supporting neither — so the clients that most need to look ordinary were the ones that could not GREASE at all.

  `EchGreaseConfig::without_provider` takes an `HpkeSuite` instead of an `&dyn Hpke` and fills the encapsulated key with random bytes of the length the KEM implies. For X25519 that is not a distinction anything on the wire can draw. It refuses a KEM whose length it does not know rather than guessing: a key of the wrong size is worse than no extension, since it looks like a client confused about its own configuration.

  Found the hard way — reading a ClientHello off a GL-XE300 with tcpdump and counting fifteen extensions where x86 had sixteen.

## Not in scope

- `signature_algorithms` order — comes from the verifier, so a caller can already control it
- `supported_groups` order — comes from `CryptoProvider::kx_groups`, likewise
- the browser profiles themselves — those go in clash-rs, where a follow-up PR wires `client-fingerprint` to this

## Note on the branch

Based on `watfaq/0.23.40`. `Cargo.lock` in that branch is missing an `x25519-dalek` entry and a build regenerates it; I left that alone to keep the diff to the change.
